### PR TITLE
fix: Suppress `make sync` message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ show_fixture:
 	@echo "_B2F_BASHRC: $(_B2F_BASHRC)"
 
 sync: $(_B2F_ALIASES_FILE)
+	@echo > /dev/null
 
 $(_B2F_ALIASES_FILE): $(_B2F_BASHRC)
 	_B2F_BASHRC=$(_B2F_BASHRC) bash bash2fish_translator.bash > $@


### PR DESCRIPTION
make: Nothing to be done for `sync'.
↓
(no output)

ref:
https://stackoverflow.com/questions/3417391/suppress-nothing-to-be-done-for-all

